### PR TITLE
CLI: Read multiple URLs as inputs (or STDIN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ Then, the simplest use is `a11ym` with an URL:
 $ ./a11ym http://example.org/
 ```
 
+All URLs accessible from `http://example.org/` will be tested. See the
+`--maximum-urls` options to reduce the number of URLs to test.
+
 Then open `a11ym_output/index.html` and browser the result!
 
-### Compute several URLs
+### List of URLs instead of crawling
 
 You can compute several URLs by adding them to the command-line, like this:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ First, see the help:
 ```sh
 $ ./a11ym --help
 
-  Usage: a11ym [options] <url>
+  Usage: a11ym [options] url …
 
   Options:
 
@@ -46,10 +46,28 @@ $ ./a11ym --help
 Then, the simplest use is `a11ym` with an URL:
 
 ```sh
-$ ./a11ym http://example.org
+$ ./a11ym http://example.org/
 ```
 
 Then open `a11ym_output/index.html` and browser the result!
+
+### Compute several URLs
+
+You can compute several URLs by adding them to the command-line, like this:
+
+```sh
+$ ./a11ym http://example.org/A http://example.org/B http://example.org/C
+```
+
+Alternatively, this is possible to read URLs from STDIN, as follows:
+
+```sh
+$ cat URLs.lists | ./a11ym -
+```
+
+Note the `-`: It means “Read URLs from STDIN please”.
+
+When reading several URLs, the `--maximum-depth` option will be forced to 1.
 
 ## Possible output
 
@@ -101,7 +119,7 @@ $ grunt --sniffers-directory my/sniffers/ --sniffers-output my_sniffers.js
 Then, to effectively use it:
 
 ```sh
-$ a11ym --sniffers my_sniffers.js --standard MyStandard http://example.org/
+$ ./a11ym --sniffers my_sniffers.js --standard MyStandard http://example.org/
 ```
 
 ## License

--- a/a11ym
+++ b/a11ym
@@ -263,7 +263,7 @@ crawler.on('fetchcomplete', function(queueItem) {
     urls.push({url: url});
 });
 
-var computeURLToCrawler = function (crawler) {
+var addURLToCrawler = function (crawler) {
     var first = true;
 
     return function (value) {
@@ -292,13 +292,13 @@ if (1 === program.args.length && '-' === program.args[0]) {
     crawler.maxDepth = 1;
     readline
         .createInterface(process.stdin, undefined)
-        .on('line', computeURLToCrawler(crawler))
+        .on('line', addURLToCrawler(crawler))
         .on('close', function () { crawler.start(); });
 } else {
     if (1 < program.args.length) {
         crawler.maxDepth = 1;
     }
 
-    program.args.forEach(computeURLToCrawler(crawler));
+    program.args.forEach(addURLToCrawler(crawler));
     crawler.start();
 }

--- a/a11ym
+++ b/a11ym
@@ -268,7 +268,6 @@ var computeURLToCrawler = function (crawler) {
 
     return function (value) {
         var url = crawler.processURL(value);
-        console.log(url);
 
         if (true === first) {
             first                   = false;

--- a/a11ym
+++ b/a11ym
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 
-var Crawler = require('simplecrawler');
-var URL     = require('url');
-var async   = require('async');
-var pa11y   = require('pa11y');
-var process = require('process');
-var program = require('commander');
+var Crawler  = require('simplecrawler');
+var URL      = require('url');
+var async    = require('async');
+var pa11y    = require('pa11y');
+var process  = require('process');
+var program  = require('commander');
+var readline = require('readline');
 
 program
-    .usage('[options] <url>')
+    .usage('[options] url …')
     .option(
         '-c, --filter-by-codes <codes>',
         'Filter results by comma-separated WCAG codes (e.g. `H25,H91,G18`).'
@@ -62,9 +63,7 @@ program
     )
     .parse(process.argv);
 
-program.url = program.args[0];
-
-if (!program.url) {
+if (!program.args[0]) {
     program.help();
     process.exit(1);
 }
@@ -166,7 +165,6 @@ var isErrorOrWarning = function (result) {
 
 var hasErrors = false;
 
-var url  = URL.parse(program.url);
 var urls = async.queue(
     function (task, onTaskComplete) {
         console.log('Run: ' + task.url + '.');
@@ -190,19 +188,34 @@ urls.drain = function () {
     }
 };
 
-var crawler             = new Crawler(url.hostname);
-crawler.initialPath     = url.path;
-crawler.initialPort     = url.port || 80;
-crawler.initialProtocol = (url.protocol || 'http').replace(':', '');
-crawler.interval        = 100;
-crawler.maxConcurrency  = 5;
-crawler.maxDepth        = +program.maximumDepth;
+var parseURL = function (url) {
+    var parsed = URL.parse(url);
+
+    if (!parsed.protocol) {
+        parsed.protocol = 'http';
+    } else {
+        parsed.protocol = parsed.protocol.replace(':', '');
+    }
+
+    if (!parsed.port) {
+        parsed.port = 'http' === parsed.protocol ? 80 : 443;
+    }
+
+    return parsed;
+};
+
+var crawler            = new Crawler();
+crawler.interval       = 100;
+crawler.maxConcurrency = 5;
+crawler.maxDepth       = +program.maximumDepth;
+crawler.filterByDomain = true;
+
+var maximumUrls = +program.maximumUrls;
 
 // Deactivate invalid SSL certificate checking.
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 crawler.ignoreInvalidSSL = true;
 
-var maximumUrls   = program.maximumUrls;
 var filterByUrls  = null;
 var excludeByUrls = null;
 
@@ -250,4 +263,43 @@ crawler.on('fetchcomplete', function(queueItem) {
     urls.push({url: url});
 });
 
-crawler.start();
+var computeURLToCrawler = function (crawler) {
+    var first = true;
+
+    return function (value) {
+        var url = crawler.processURL(value);
+        console.log(url);
+
+        if (true === first) {
+            first                   = false;
+            crawler.host            = url.host;
+            crawler.initialProtocol = url.protocol;
+            crawler.initialPort     = url.port;
+            crawler.initialPath     = url.path;
+        } else {
+            ++maximumUrls;
+        }
+
+        crawler.queue.add(
+            url.protocol,
+            url.host,
+            url.port,
+            url.path
+        );
+    };
+};
+
+if (1 === program.args.length && '-' === program.args[0]) {
+    crawler.maxDepth = 1;
+    readline
+        .createInterface(process.stdin, undefined)
+        .on('line', computeURLToCrawler(crawler))
+        .on('close', function () { crawler.start(); });
+} else {
+    if (1 < program.args.length) {
+        crawler.maxDepth = 1;
+    }
+
+    program.args.forEach(computeURLToCrawler(crawler));
+    crawler.start();
+}


### PR DESCRIPTION
Fix #10.

Now this is possible to do this:

    $ a11ym http://domainA.org/ http://domainB.org/ http://domainC.org/

When computing mulitple URLs, the `--maximum-depth` option will be
forced to 1.

We can also read these URLs from STDIN, like:

    $ cat listOfUrls.txt | ./a11ym -

Note the `-` specifying “Read from STDIN please”.