### PR TITLE
CLI: Add the `--http-auth-*` options

### DIFF
--- a/a11ym
+++ b/a11ym
@@ -99,6 +99,14 @@ program
         4
     )
     .option(
+        '--http-auth-user <http_auth_user>',
+        'Username to authenticate all HTTP requests.'
+    )
+    .option(
+        '--http-auth-password <http_auth_password>',
+        'Password to authenticate all HTTP requests.'
+    )
+    .option(
         '--http-tls-disable',
         'Disable TLS/SSL when crawling or downloading pages.'
     )

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -202,6 +202,12 @@ function start(program, queue) {
         crawler.ignoreInvalidSSL                 = true;
     }
 
+    if (undefined !== program.httpAuthUser) {
+        crawler.needsAuth = true;
+        crawler.authUser  = program.httpAuthUser;
+        crawler.authPass  = program.httpAuthPassword;
+    }
+
     if (undefined !== program.filterByUrls) {
         var filterByUrlRegex = new RegExp(program.filterByUrls, 'i');
 

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -50,8 +50,19 @@ module.exports = function(program) {
         log      : reporter,
         standard : program.standard,
         standards: [program.standard],
-        htmlcs   : program.sniffers
+        htmlcs   : program.sniffers,
+        page     : {
+            headers: {
+                'User-Agent': 'liip/a11ym'
+            },
+            settings: {}
+        }
     };
+
+    if (undefined !== program.httpAuthUser) {
+        options.page.settings.userName = program.httpAuthUser;
+        options.page.settings.password = program.httpAuthPassword;
+    }
 
     var filterByCodes  = function (results) { return results; };
     var excludeByCodes = function (results) { return results; };


### PR DESCRIPTION
Fix #40.

It is now possible to specify the user and the password, respectively with the `--http-auth-user` and `--http-auth-password` options, to authenticate HTTP requests.

Please, @krtek4, can you do a review?