### PR TITLE
Fixed bug whereby uri's more than one folder deep aren't crawled

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -83,7 +83,7 @@ function didFetch(url) {
 crawler.oldQueueUrl = crawler.queueURL;
 crawler.queueURL    = function(url, queueItem) {
     var parsedUrl    = typeof url === 'object' ? url : crawler.processURL(url, queueItem)
-    var urlQueueName = (parsedUrl.uriPath.split('/', 2)[1] || '__root__');
+    var urlQueueName = (parsedUrl.uriPath || '__root__');
 
     var newUrl =
         parsedUrl.protocol + '://' +


### PR DESCRIPTION
`urlQueueName` was being limited to a single folder, just using the uriPath as a key fixes it.