### PR TITLE
Crawler: Fix URL formats

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -82,13 +82,20 @@ function didFetch(url) {
 // Register our own `queueURL` so we can have buckets.
 crawler.oldQueueUrl = crawler.queueURL;
 crawler.queueURL    = function(url, queueItem) {
-    var parsedUrl    = typeof url === 'object' ? url : crawler.processURL(url, queueItem)
-    var urlQueueName = (parsedUrl.uriPath.split('/', 2)[1] || '__root__');
+    var parsedUrl    = 'object' === typeof url ? url : parseURL(url);
+    var urlQueueName = (parsedUrl.path.split('/', 2)[1] || '__root__');
 
     var newUrl =
         parsedUrl.protocol + '://' +
-        parsedUrl.host + ':' +
-        parsedUrl.port +
+        parsedUrl.host +
+        (
+            !(
+                ('https' === parsedUrl.protocol && 443 === parsedUrl.port) ||
+                ('http'  === parsedUrl.protocol &&  80 === parsedUrl.port)
+            )
+            ? ':' + parsedUrl.port
+            : ''
+        ) +
         parsedUrl.path;
 
     if (undefined !== history[newUrl]) {
@@ -115,7 +122,7 @@ crawler.queueURL    = function(url, queueItem) {
     }
 
     urlQueues[urlQueueName].push({
-        url       : url,
+        url       : newUrl,
         queueItem : queueItem
     });
 };
@@ -183,7 +190,14 @@ function parseURL(url) {
         parsed.port = 'http' === parsed.protocol ? 80 : 443;
     }
 
-    return parsed;
+    return {
+        protocol: parsed.protocol,
+        host    : parsed.hostname,
+        port    : parsed.port,
+        path    : parsed.path,
+        uriPath : parsed.path,
+        depth   : 2
+    };
 }
 
 // Helper to add a URL to the crawler queue.
@@ -191,13 +205,17 @@ var addURL = new function () {
     var firstUrl = true;
 
     return function (_url) {
-        var url = crawler.processURL(_url);
+        var url = parseURL(_url);
 
         if (!url.host) {
             process.stderr.write('URL ' + _url + ' is invalid. Ignore it.\n');
 
             return;
         }
+
+        logger.write(
+            logger.colorize.white('Initializing with ' + _url + '.\n')
+        );
 
         if (true === firstUrl) {
             firstUrl                = false;


### PR DESCRIPTION
We have too much URL formats in the crawler. Sometimes port is defined, sometimes not, sometimes we receive an object, sometimes a string… This patch tries to clean this up. Also, it fixes an issue with the crawler that assumes 80 is always the default port while it is 443 for HTTPS.