### PR TITLE
Reporter: Back to listing goes back in history

### DIFF
--- a/reporter/templates/report.html
+++ b/reporter/templates/report.html
@@ -173,6 +173,18 @@
   </style>
 
   <script>
+    function backToListing() {
+        history.back();
+
+        // If there is no history, we try to reach the `index.html` page.
+        setTimeout(
+            function () {
+                window.location = 'index.html'
+            },
+            1000
+        );
+    }
+
     function toggleFilter(name) {
         var classList = document.querySelector('#results').classList;
 
@@ -294,7 +306,7 @@
 
   <div id="controls">
     <p>
-      <a href="index.html">Back to report listing</a>
+      <a href="javascript:backToListing()">Back to report listing</a>
     </p>
     <p>
       Filter by:


### PR DESCRIPTION
Fix #56.

Why? Because the `index.html` can be in another place, so hardcoding the
link to `index.html` can be wrong. However, we take care that if there
is no history, we fallback to the previous behavior and try to reach the
`index.html` page.