### PR TITLE
Reporter: `mkdir` is now synchronous

### DIFF
--- a/reporter/html.js
+++ b/reporter/html.js
@@ -21,7 +21,7 @@ function emptyFunction() {}
 
 function config(options) {
     outputDirectory = options.outputDirectory;
-    mkdirp(outputDirectory);
+    mkdirp.sync(outputDirectory);
     indexStream = fs.createWriteStream(
         outputDirectory + '/index.html',
         {


### PR DESCRIPTION
Having it asynchronous causes an issue when opening the `index.html` stream just after.