### PR TITLE
CLI: Fix progression max. number

### DIFF
--- a/a11ym
+++ b/a11ym
@@ -206,15 +206,14 @@ if ((1 === program.args.length && '-' === program.args[0]) || 1 < program.args.l
     maximumUrls = 0;
 
     var add = function (url) {
-        ++maximumUrls;
+        program.maximumUrls = ++maximumUrls;
         testQueue.push(url);
     };
 
     if('-' === program.args[0]) {
         readline
             .createInterface(process.stdin, undefined)
-            .on('line', add)
-            .on('close', function() { program.maximumUrls = maximumUrls; });
+            .on('line', add);
     } else {
         program.args.forEach(add);
         program.maximumUrls = maximumUrls;


### PR DESCRIPTION
While using the pipe to receive URLs to compute, it is possible to see:
`1/128` even if the total of URLs is 7. Why? Because the
`program.maximumUrls` variable was updated after having read the whole
pipe. Remind that the testing starts as soon as possible, so it can
start before reaching the end of the pipe.

Now, this variable is updated every time to provide a more accurate
progression result to the user.