### PR TITLE
Documentation: Install a11ym globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ reap the benefits.
 
 ```sh
 $ npm install -g phantomjs
-$ npm install the-a11y-machine
+$ npm install -g the-a11y-machine
 ```
 
 If you would like to validate your pages against the HTML5 recommendation, then


### PR DESCRIPTION
Fix https://github.com/liip/TheA11yMachine/issues/75.

We have several issues when people are installing a11ym without a
`package.json` file. Thus, NPM complains about it, and triggers some
warnings. By installing it globally, a `package.json` file is
automatically created, so the amount of users raising this should
drop. NPM users will know what to do with the `-g` flag.