### PR TITLE
Crawler: Handle redirection fetching

### DIFF
--- a/a11ym
+++ b/a11ym
@@ -134,7 +134,13 @@ var isStopped = false;
 
 // Force to quit the program. If errors, exit with a non 0 exit code.
 function quit() {
-    process.exit(true === hasErrors ? 2 : 0);
+    if (true === hasErrors) {
+        logger.write(loggers.colorize.red('Quiting with errors…'));
+        process.exit(2);
+    } else {
+        logger.write(logger.colorize.green('Quitting with success…'));
+        process.exit(0);
+    }
 }
 
 // Kill the test queue and stop the crawler.

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -39,6 +39,9 @@ var process = require('process');
 // Set the logger.
 var logger = null;
 
+// History of all URL being crawled or already crawled.
+var history = {};
+
 function newCrawler(initialUrl) {
     // Set the crawler.
     var crawler = new Crawler(initialUrl);
@@ -50,9 +53,6 @@ function newCrawler(initialUrl) {
     crawler.filterByDomain           = true;
     crawler.allowInitialDomainChange = false;
     crawler.scanSubdomains           = true;
-
-    // History of all URL being crawled or already crawled.
-    var history = {};
 
     // Register our own `queueURL` so we can have buckets.
     crawler.oldQueueUrl = crawler.queueURL;
@@ -73,7 +73,7 @@ function newCrawler(initialUrl) {
             ) +
             parsedUrl.path;
 
-        if (undefined !== history[newUrl]) {
+        if (true === history[newUrl]) {
             return;
         }
 
@@ -224,6 +224,8 @@ var addURL = new function () {
         logger.write(
             logger.colorize.white('Initializing with ' + _url + '.\n')
         );
+
+        history[_url] = true;
 
         if (true === firstUrl) {
             firstUrl = false;

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -105,7 +105,8 @@ function newCrawler(initialUrl) {
     crawler
         .on('fetch404', error404)
         .on('fetcherror', error)
-        .on('fetchcomplete', fetchComplete);
+        .on('fetchcomplete', fetchComplete)
+        .on('fetchredirect', fetchRedirect);
 
     return crawler;
 }
@@ -180,6 +181,17 @@ function fetchComplete(queueItem) {
         testQueue.push(queueItem.url);
     }
 
+    didFetch(queueItem.url);
+}
+
+function fetchRedirect(queueItem, redirectQueueItem) {
+    logger.write(
+        logger.colorize.yellow(
+            'Fetch complete for ' + queueItem.url +
+            ', and redirect to ' + redirectQueueItem.url + '.\n'
+        )
+    );
+    history[queueItem.url] = true;
     didFetch(queueItem.url);
 }
 


### PR DESCRIPTION
Fix #78.

The key part is to handle redirection fetching to call the `didFetch` function, which will tell the queue to execute the next task. This is why sometimes the queue was blocked and stopped when a redirection was encountered.