### PR TITLE
Bin: Filter results by error level

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ $ ./a11ym --help
   Options:
 
     -h, --help                                 output usage information
+    -e, --error-level <error_level>            Minimum error level: In ascending order, `notice` (default), `warning`, and `error` (e.g. `warning` includes all warnings and errors).
     -c, --filter-by-codes <codes>              Filter results by comma-separated WCAG codes (e.g. `H25,H91,G18`).
     -C, --exclude-by-codes <codes>             Exclude results by comma-separated WCAG codes (e.g. `H25,H91,G18`).
     -d, --maximum-depth <depth>                Explore up to a maximum depth (hops).

--- a/a11ym
+++ b/a11ym
@@ -43,6 +43,11 @@ var readline = require('readline');
 program
     .usage('[options] url …')
     .option(
+        '-e, --error-level <error_level>',
+        'Minimum error level: In ascending order, `notice` (default), `warning`, and `error` (e.g. `warning` includes all warnings and errors).',
+        'notice'
+    )
+    .option(
         '-c, --filter-by-codes <codes>',
         'Filter results by comma-separated WCAG codes (e.g. `H25,H91,G18`).'
     )

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -80,31 +80,43 @@ function tester(program) {
         options.page.settings.password = program.httpAuthPassword;
     }
 
-    var filterByCodes  = function (results) { return results; };
-    var excludeByCodes = function (results) { return results; };
+    var errorLevelToInteger = function (errorLevel) {
+        switch (errorLevel) {
+            case 'notice':
+                return 1;
+
+            case 'warning':
+                return 2;
+
+            case 'error':
+                return 3;
+
+            default:
+                return 0;
+        }
+    };
+
+    var minimumErrorLevel   = errorLevelToInteger(program.errorLevel);
+    var filterByErrorLevels = function (errorLevel) {
+        return minimumErrorLevel <= errorLevelToInteger(errorLevel);
+    };
+    var filterByCodes  = function () { return true; };
+    var excludeByCodes = function () { return true; };
 
     if (undefined !== program.filterByCodes) {
         var filterByCodesRegex = new RegExp('\\b(' + program.filterByCodes.replace(/[\s,]/g, '|') + ')\\b', 'i');
 
-        filterByCodes = function(results) {
-            return results.filter(
-                function(result) {
-                    return result.code && filterByCodesRegex.test(result.code);
-                }
-            );
-        }
+        filterByCodes = function(code) {
+            return code && filterByCodesRegex.test(code);
+        };
     }
 
     if (undefined !== program.excludeByCodes) {
         var excludeByCodesRegex = new RegExp('\\b(' + program.excludeByCodes.replace(/[\s,]/g, '|') + ')\\b', 'i');
 
-        excludeByCodes = function(results) {
-            return results.filter(
-                function(result) {
-                    return result.code && !excludeByCodesRegex.test(result.code);
-                }
-            );
-        }
+        excludeByCodes = function(code) {
+            return code && !excludeByCodesRegex.test(code);
+        };
     }
 
     var testHTML = new function () {
@@ -157,6 +169,11 @@ function tester(program) {
                                     };
                                 }
                             )
+                            .filter(
+                                function (result) {
+                                    return filterByErrorLevels(result.level);
+                                }
+                            )
                     );
                 }
             );
@@ -166,8 +183,6 @@ function tester(program) {
         if (!a11yStandard) {
             return function (url, onComplete) {
                 onComplete(null, []);
-
-                return;
             };
         }
 
@@ -201,26 +216,32 @@ function tester(program) {
                         return _onError(error, options.log.error);
                     }
 
-                    results = results.map(
-                        function (result) {
-                            return {
-                                type: 'a11y',
-                                // error, warning or notice.
-                                level: result.type,
-                                // e.g. WCAG2AA.PrincipleX.GuidelineX_Y.X_Y_Z.….…
-                                code: result.code,
-                                // e.g. <title>Foobar</title>
-                                context: result.context,
-                                // e.g. 'html > head > title'
-                                selector: result.selector,
-                                // message
-                                message: result.message
-                            };
-                        }
-                    );
-
-                    results = filterByCodes(results);
-                    results = excludeByCodes(results);
+                    results =
+                        results
+                            .map(
+                                function (result) {
+                                    return {
+                                        type: 'a11y',
+                                        // error, warning or notice.
+                                        level: result.type,
+                                        // e.g. WCAG2AA.PrincipleX.GuidelineX_Y.X_Y_Z.….…
+                                        code: result.code,
+                                        // e.g. <title>Foobar</title>
+                                        context: result.context,
+                                        // e.g. 'html > head > title'
+                                        selector: result.selector,
+                                        // message
+                                        message: result.message
+                                    };
+                                }
+                            )
+                            .filter(
+                                function (result) {
+                                    return filterByErrorLevels(result.level) &&
+                                        filterByCodes(result.code) &&
+                                        excludeByCodes(result.code);
+                                }
+                            );
 
                     _onSuccess(results, options.log.results);
                 }

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -6,10 +6,10 @@ var fs     = require('fs');
 var mkdirp = require('mkdirp');
 
 module.exports = {
-    config: config,
-    error: reportError,
-    debug: emptyFunction,
-    info: emptyFunction,
+    config : config,
+    error  : reportError,
+    debug  : emptyFunction,
+    info   : emptyFunction,
     results: reportResults
 };
 


### PR DESCRIPTION
Fix #71.

The following command:

```sh
$ ./a11y --error-level error <url>
```

will only produce error message, discarding notice and warning messages.

The default value for `--error-level` is `notice`. The default behavior is kept.