### PR TITLE
Bin: `a11ym_output` is created in the CWD

### DIFF
--- a/a11ym
+++ b/a11ym
@@ -35,6 +35,7 @@
 var Logger   = require('./lib/logger');
 var Tester   = require('./lib/tester');
 var async    = require('async');
+var fs       = require('fs');
 var process  = require('process');
 var program  = require('commander');
 var readline = require('readline');
@@ -143,7 +144,10 @@ function quit() {
         logger.write(loggers.colorize.red('Quiting with errors…'));
         process.exit(2);
     } else {
-        logger.write(logger.colorize.green('Quitting with success…'));
+        logger.write(
+            logger.colorize.green('Quitting with success…') + "\n" +
+            'Report index at file://' + fs.realpathSync(program.output) + "\n"
+        );
         process.exit(0);
     }
 }

--- a/a11ym
+++ b/a11ym
@@ -67,8 +67,8 @@ program
     )
     .option(
         '-o, --output <output_directory>',
-        'Output directory.',
-        __dirname + '/a11ym_output'
+        'Output directory, like `./a11ym_output` (default).',
+        './a11ym_output'
     )
     .option(
         '-r, --report <report>',


### PR DESCRIPTION
Fix #87.

The default output directory is created in the current working directory instead of the root installation directory.

Also print the path to the report in case of success.