### PR TITLE
Report: Support options

### DIFF
--- a/a11ym
+++ b/a11ym
@@ -44,7 +44,8 @@ program
     )
     .option(
         '-e, --error-level <error_level>',
-        'Minimum error level: In ascending order, `notice` (default), `warning`, and `error` (e.g. `warning` includes all warnings and errors).'
+        'Minimum error level: In ascending order, `notice` (default), `warning`, and `error` (e.g. `warning` includes all warnings and errors).',
+        /^notice|warning|error$/i
     )
     .option(
         '-c, --filter-by-codes <codes>',
@@ -56,11 +57,13 @@ program
     )
     .option(
         '-d, --maximum-depth <depth>',
-        'Explore up to a maximum depth (hops).'
+        'Explore up to a maximum depth (hops).',
+        /^\d+$/
     )
     .option(
         '-m, --maximum-urls <maximum_urls>',
-        'Maximum number of URLs to compute.'
+        'Maximum number of URLs to compute.',
+        /^\d+$/
     )
     .option(
         '-o, --output-directory <output_directory>',
@@ -88,7 +91,8 @@ program
     )
     .option(
         '-w, --workers <workers>',
-        'Number of workers, i.e. number of URLs computed in parallel.'
+        'Number of workers, i.e. number of URLs computed in parallel.',
+        /^\d+$/i
     )
     .option(
         '--http-auth-user <http_auth_user>',

--- a/a11ym
+++ b/a11ym
@@ -71,7 +71,11 @@ program
     )
     .option(
         '-r, --report <report>',
-        'Report format: `cli`, `csv`, `html` (default), `json` or `markdown`.'
+        'Report format: `cli`, `csv`, `html` (default), `json` or `markdown`, or your own absolute path to a reporter.'
+    )
+    .option(
+        '--report-options <options>',
+        'Report options, as a JSON formatted object.'
     )
     .option(
         '-s, --standards <standards>',

--- a/a11ym.yml.example
+++ b/a11ym.yml.example
@@ -25,6 +25,10 @@ outputDirectory: ./a11ym_output
 # Report format: `cli`, `csv`, `html`, `json`, or `markdown`.
 report: html
 
+# Report options.
+reportOptions:
+  - foo: bar
+
 # Standard to use: `WCAG2A`, `WCAG2AA`, `WCAG2AAA`, `Section508`, `HTML` or your own. `HTML` can be combined with any other by a comma.
 standards: WCAG2AA
 

--- a/lib/a11ym.js
+++ b/lib/a11ym.js
@@ -49,6 +49,7 @@ var defaultOptions = {
     maximumUrls     : 128,
     outputDirectory : './a11ym_output',
     report          : 'html',
+    reportOptions   : {},
     standards       : 'WCAG2AA',
     sniffers        : __dirname + '/../resource/sniffers.js',
     filterByUrls    : undefined,
@@ -137,6 +138,15 @@ module.exports = {
     defaultOptions: defaultOptions,
     start         : function (options, inputs) {
         inputs = inputs || [];
+
+        if (options.reportOptions &&
+            typeof options.reportOptions === 'string') {
+            options.reportOptions = JSON.parse(options.reportOptions);
+
+            if (typeof options.reportOptions !== 'object') {
+                throw "Report options must be a JSON formatted object. Got:" + options.reportOptions + ".";
+            }
+        }
 
         var optionsFromConfigurationFile = {};
         var configurationFile            = options.bootstrap;

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -48,7 +48,6 @@ function tester(options) {
 
     switch (options.report) {
         case 'html':
-        case 'json':
             reporter = require('../reporter/html');
             reporter.config(options.reportOptions);
 
@@ -56,6 +55,7 @@ function tester(options) {
 
         case 'cli':
         case 'csv':
+        case 'json':
             reporter = require('../node_modules/pa11y/reporter/' + options.report);
 
             break;

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -40,13 +40,31 @@ var pa11y = require('pa11y');
 function tester(options) {
     var reporter = null;
 
-    if (-1 !== ['cli', 'csv', 'json'].indexOf(options.report)) {
-        reporter = require('../node_modules/pa11y/reporter/' + options.report);
-    } else {
-        reporter = require('../reporter/html');
-        reporter.config({
-            outputDirectory: options.outputDirectory
-        });
+    if (!options.reportOptions) {
+        options.reportOptions = {};
+    }
+
+    options.reportOptions.outputDirectory = options.outputDirectory;
+
+    switch (options.report) {
+        case 'html':
+        case 'json':
+            reporter = require('../reporter/html');
+            reporter.config(options.reportOptions);
+
+            break;
+
+        case 'cli':
+        case 'csv':
+            reporter = require('../node_modules/pa11y/reporter/' + options.report);
+
+            break;
+
+        default:
+            console.log(options.report);
+            console.log(options.reportOptions);
+            reporter = require(options.report);
+            reporter.config(options.reportOptions);
     }
 
     var a11yStandard = null;

--- a/lib/tester.js
+++ b/lib/tester.js
@@ -61,8 +61,6 @@ function tester(options) {
             break;
 
         default:
-            console.log(options.report);
-            console.log(options.reportOptions);
             reporter = require(options.report);
             reporter.config(options.reportOptions);
     }

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -1,5 +1,35 @@
 'use strict';
 
+/**
+ * Copyright (c) 2016, Ivan Enderlin and Liip
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 var _      = require('underscore');
 var crypto = require('crypto');
 var fs     = require('fs');

--- a/reporter/html.js
+++ b/reporter/html.js
@@ -50,6 +50,10 @@ var statistics      = [];
 function emptyFunction() {}
 
 function config(options) {
+    if (!options.outputDirectory) {
+        throw "The `html` reporter must have a `outputDirectory` option.";
+    }
+
     outputDirectory = options.outputDirectory;
     mkdirp.sync(outputDirectory);
     indexHtmlStream = fs.createWriteStream(


### PR DESCRIPTION
New `--report-options` (CLI) and `reportOptions` (config file) feature. It allows to pass options to the reporter.

`--report` (CLI) and `report` (config file) support a path to a reporter, so you can write your own.