### PR TITLE
HTML: Increase stack size to 2048k

### DIFF
--- a/lib/tester.js
+++ b/lib/tester.js
@@ -157,6 +157,7 @@ function tester(options) {
             var vnu     = spawn(
                 'java',
                 [
+                    '-Xss2048k',
                     '-jar',
                     __dirname + '/../resource/vnu/vnu.jar',
                     '--format',


### PR DESCRIPTION
Fix #99.

When a page is very large, algorithms checking the HTML validity needs a large stack (due to recursivity for instance). Instead of having people enjoying this error, we increase the size to 2048k upfront, which should be enough for the majority of cases.

Please @stevenfaulkner, could you validate this patch?