### PR TITLE
Update package for html codesniffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/liip/TheA11yMachine#readme",
   "main": "./lib/a11ym.js",
   "dependencies": {
-    "HTML_CodeSniffer": "https://github.com/squizlabs/HTML_CodeSniffer#master",
+    "html_codesniffer": "^2.2.0",
     "async": "^2.1.4",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",


### PR DESCRIPTION
Hey

Some recent changes in html_codesniffer broke "npm install" because they updated the package name in registry. It might be safer if we point to a stable version.

Thanks,
Lu