### PR TITLE
Add async callback option to a11ym runner

### DIFF
--- a/lib/a11ym.js
+++ b/lib/a11ym.js
@@ -59,7 +59,8 @@ var defaultOptions = {
     httpAuthPassword: undefined,
     httpTlsDisable  : undefined,
     verbose         : true,
-    ignoreRobotsTxt : false
+    ignoreRobotsTxt : false,
+    processCallback: undefined
 };
 
 // Set the logger.
@@ -203,6 +204,12 @@ module.exports = {
         logger      = new Logger(options);
         tester      = Tester(options);
         maximumUrls = +options.maximumUrls;
+
+        if (typeof (options.processCallback) === 'function') {
+            process.on('exit', function(code) {
+                options.processCallback(code);
+            });
+        }
 
         testQueue = async.queue(
             function (url, onTaskComplete) {


### PR DESCRIPTION
This PR adds a `processCallback` option that can be passed in when calling `lib/a11ym.js` programmatically. This allows for the runner to call the callback when the testing process ends, either naturally or via `ctrl+c`/`SIGINT`.

This change is needed to support running `TheA11yMachine` as a `Grunt` task: https://gruntjs.com/creating-tasks. Once this gets merged, I could build a Grunt plugin to run `TheA11yMachine`.